### PR TITLE
Error handling for bad API call; ioutil to io

### DIFF
--- a/translate.go
+++ b/translate.go
@@ -13,7 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -31,6 +31,10 @@ var (
 type Response struct {
 	Data struct {
 		Translations []Translation
+	}
+	Error struct {
+		Code    int
+		Message string
 	}
 }
 
@@ -63,7 +67,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		log.Fatal(err)
@@ -71,6 +75,12 @@ func main() {
 	var r Response
 	if err := json.Unmarshal(data, &r); err != nil {
 		log.Fatal(err)
+	}
+	switch {
+	case r.Error.Code != 0, r.Error.Message != "":
+		log.Fatalf("(%d) %s", r.Error.Code, r.Error.Message)
+	case len(r.Data.Translations) == 0:
+		log.Fatal(string(data))
 	}
 	for _, t := range r.Data.Translations {
 		fmt.Printf("%s (%s)\n", html.UnescapeString(t.TranslatedText), t.DetectedSourceLanguage)

--- a/translate.go
+++ b/translate.go
@@ -32,10 +32,7 @@ type Response struct {
 	Data struct {
 		Translations []Translation
 	}
-	Error struct {
-		Code    int
-		Message string
-	}
+	Error interface{}
 }
 
 type Translation struct {
@@ -76,10 +73,7 @@ func main() {
 	if err := json.Unmarshal(data, &r); err != nil {
 		log.Fatal(err)
 	}
-	switch {
-	case r.Error.Code != 0, r.Error.Message != "":
-		log.Fatalf("(%d) %s", r.Error.Code, r.Error.Message)
-	case len(r.Data.Translations) == 0:
+	if r.Error != nil {
 		log.Fatal(string(data))
 	}
 	for _, t := range r.Data.Translations {


### PR DESCRIPTION
Addresses #3; also updates deprecated ioutil to io.

I ended up just dumping the entire error JSON, so as not to miss crucial information. I like the idea of a small, cherry-picked message, with a final prompt to run -v for the full error:

```none
2000/1/1 00:00 (400) Bad language pair: de|rm
2000/1/1 00:00 rerun with -v for full error
```

and add a -v flag.